### PR TITLE
feat: add various new font-face rules

### DIFF
--- a/includes/FontFaceAtRuleSanitizerExtender.php
+++ b/includes/FontFaceAtRuleSanitizerExtender.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @file
+ */
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\TemplateStylesExtender;
+
+use Wikimedia\CSS\Grammar\Alternative;
+use Wikimedia\CSS\Grammar\MatcherFactory;
+use Wikimedia\CSS\Sanitizer\FontFaceAtRuleSanitizer;
+
+
+class FontFaceAtRuleSanitizerExtender extends FontFaceAtRuleSanitizer {
+
+	/**
+	 * @param MatcherFactory $matcherFactory
+	 */
+	public function __construct( MatcherFactory $matcherFactory ) {
+		parent::__construct( $matcherFactory );
+
+		// Only allow the font-family if it begins with "TemplateStyles"
+		$this->propertySanitizer->setKnownProperties( [
+			'adjust-size' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] ),
+			'ascent-override' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] ),
+			'descent-override' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] ),
+			'font-display' => new Alternative( [
+				new KeywordMatcher( [ 'auto', 'block', 'swap', 'fallback', 'optional' ] )
+			] ),
+		] );
+	}
+}

--- a/includes/FontFaceAtRuleSanitizerExtender.php
+++ b/includes/FontFaceAtRuleSanitizerExtender.php
@@ -34,13 +34,13 @@ class FontFaceAtRuleSanitizerExtender extends FontFaceAtRuleSanitizer {
 
 		// Only allow the font-family if it begins with "TemplateStyles"
 		$this->propertySanitizer->setKnownProperties( [
-			'adjust-size' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] ),
 			'ascent-override' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] ),
 			'descent-override' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] ),
 			'font-display' => new Alternative( [
 				new KeywordMatcher( [ 'auto', 'block', 'swap', 'fallback', 'optional' ] )
 			] ),
-			'line-gap-override' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] )
+			'line-gap-override' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] ),
+			'size-adjust' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] )
 		] );
 	}
 }

--- a/includes/FontFaceAtRuleSanitizerExtender.php
+++ b/includes/FontFaceAtRuleSanitizerExtender.php
@@ -24,7 +24,6 @@ use Wikimedia\CSS\Grammar\Alternative;
 use Wikimedia\CSS\Grammar\MatcherFactory;
 use Wikimedia\CSS\Sanitizer\FontFaceAtRuleSanitizer;
 
-
 class FontFaceAtRuleSanitizerExtender extends FontFaceAtRuleSanitizer {
 
 	/**
@@ -41,6 +40,7 @@ class FontFaceAtRuleSanitizerExtender extends FontFaceAtRuleSanitizer {
 			'font-display' => new Alternative( [
 				new KeywordMatcher( [ 'auto', 'block', 'swap', 'fallback', 'optional' ] )
 			] ),
+			'line-gap-override' => new Alternative( [ $auto, $matcherFactory->lengthPercentage() ] )
 		] );
 	}
 }

--- a/includes/Hooks/StylesheetSanitizerHook.php
+++ b/includes/Hooks/StylesheetSanitizerHook.php
@@ -41,7 +41,7 @@ class StylesheetSanitizerHook {
 	 */
 	public static function onSanitize( $sanitizer, $propertySanitizer, $matcherFactory ): void {
 		$newRules = $sanitizer->getRuleSanitizers();
-	
+
 		if ( TemplateStylesExtender::getConfigValue(
 			'TemplateStylesExtenderEnablePrefersColorScheme',
 				true ) === true ) {

--- a/includes/Hooks/StylesheetSanitizerHook.php
+++ b/includes/Hooks/StylesheetSanitizerHook.php
@@ -22,6 +22,7 @@ declare( strict_types=1 );
 namespace MediaWiki\Extension\TemplateStylesExtender\Hooks;
 
 use MediaWiki\Extension\TemplateStyles\TemplateStylesMatcherFactory;
+use MediaWiki\Extension\TemplateStylesExtender\FontFaceAtRuleSanitizerExtender;
 use MediaWiki\Extension\TemplateStylesExtender\MatcherFactoryExtender;
 use MediaWiki\Extension\TemplateStylesExtender\StylePropertySanitizerExtender;
 use MediaWiki\Extension\TemplateStylesExtender\TemplateStylesExtender;
@@ -39,18 +40,18 @@ class StylesheetSanitizerHook {
 	 * @param TemplateStylesMatcherFactory $matcherFactory
 	 */
 	public static function onSanitize( $sanitizer, $propertySanitizer, $matcherFactory ): void {
+		$newRules = $sanitizer->getRuleSanitizers();
+	
 		if ( TemplateStylesExtender::getConfigValue(
 			'TemplateStylesExtenderEnablePrefersColorScheme',
 				true ) === true ) {
 			$factory = new MatcherFactoryExtender();
-
-			$newRules = $sanitizer->getRuleSanitizers();
 			$newRules['@media'] = new MediaAtRuleSanitizer( $factory->cssMediaQueryList() );
 			$newRules['@media']->setRuleSanitizers( $newRules );
-
-			$sanitizer->setRuleSanitizers( $newRules );
-
 		}
+
+		$newRules['@font-face'] = new FontFaceAtRuleSanitizerExtender( $matcherFactory );
+		$newRules['@font-face']->setRuleSanitizers( $newRules );
 
 		$extended = new TemplateStylesExtender();
 


### PR DESCRIPTION
Added the following rules missing from the font face sanitizer:
- ascent-override
- descent-override
- font-display
- line-gap-override
- size-adjust

Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face

I am not familiar with the code base so might need someone else to take a look and test it.