### PR TITLE
Use namespaced GlobalVarConfig

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -37,7 +37,7 @@
 		}
 	},
 	"ConfigRegistry": {
-		"TemplateStylesExtender": "GlobalVarConfig::newInstance"
+		"TemplateStylesExtender": "MediaWiki\\Config\\GlobalVarConfig::newInstance"
 	},
 	"MessagesDirs": {
 		"TemplateStylesExtender": [


### PR DESCRIPTION
The non-namespaced class alias was deprecated in MW 1.41. See also https://phabricator.wikimedia.org/T402038