### PR TITLE
Add support for CSS Grid Module Levels 2 and 3

### DIFF
--- a/includes/StylePropertySanitizerExtender.php
+++ b/includes/StylePropertySanitizerExtender.php
@@ -197,10 +197,20 @@ class StylePropertySanitizerExtender extends StylePropertySanitizer {
 			$lineNamesO,
 		] );
 
+		$subgrid = new Juxtaposition( [ $lineNamesO, new KeywordMatcher( 'subgrid' ), $lineNamesO ] );
+
 		$props['grid-template-columns'] = new Alternative( [
-			new KeywordMatcher( 'none' ), $trackList, $autoTrackList
+			new KeywordMatcher( [ 'none', 'masonry' ] ),
+			$trackList,
+			$autoTrackList,
+			$subgrid,
 		] );
 		$props['grid-template-rows'] = $props['grid-template-columns'];
+
+		$props['masonry-auto-flow'] = new Juxtaposition( [
+			new KeywordMatcher( [ 'pack', 'next' ] ),
+			Quantifier::optional( new KeywordMatcher( 'definite-first' ) )
+		] );
 
 		$this->cache[__METHOD__] = $props;
 		return $props;

--- a/includes/StylePropertySanitizerExtender.php
+++ b/includes/StylePropertySanitizerExtender.php
@@ -39,7 +39,7 @@ class StylePropertySanitizerExtender extends StylePropertySanitizer {
 	private bool $varEnabled = false;
 	private static $extendedCssSizingAdditions = false;
 	private static $extendedCss1Masking = false;
-	private static $extendedCss1Grid = false;
+	private static $extendedCss3Grid = false;
 
 	/**
 	 * @param MatcherFactory $matcherFactory
@@ -115,16 +115,16 @@ class StylePropertySanitizerExtender extends StylePropertySanitizer {
 	 *
 	 * Allow variables in grid-template-columns and grid-template-rows
 	 */
-	protected function cssGrid1( MatcherFactory $matcherFactory ) {
+	protected function cssGrid3( MatcherFactory $matcherFactory ) {
 		// @codeCoverageIgnoreStart
-		if ( self::$extendedCss1Grid && isset( $this->cache[__METHOD__] ) ) {
+		if ( self::$extendedCss3Grid && isset( $this->cache[__METHOD__] ) ) {
 			return $this->cache[__METHOD__];
 		}
 		// @codeCoverageIgnoreEnd
 
 		$var = new FunctionMatcher( 'var', new CustomPropertyMatcher() );
 
-		$props = parent::cssGrid1( $matcherFactory );
+		$props = parent::cssGrid3( $matcherFactory );
 
 		$comma = $matcherFactory->comma();
 		$customIdent = $matcherFactory->customIdent( [ 'span' ] );

--- a/tests.css
+++ b/tests.css
@@ -25,6 +25,32 @@
 }
 
 /**
+ * CSS Grid Module Level 2
+ */
+.ts-css-grid-2 {
+	grid-template-columns: subgrid;
+	grid-template-columns: [col-start] subgrid;
+	grid-template-columns: subgrid [col-end];
+	grid-template-columns: [col-start] subgrid [col-end];
+	grid-template-rows: subgrid;
+	grid-template-rows: [row-start] subgrid;
+	grid-template-rows: subgrid [row-end];
+	grid-template-rows: [row-start] subgrid [row-end];
+}
+
+/**
+ * CSS Grid Module Level 3
+ */
+.ts-css-grid-3 {
+	grid-template-columns: masonry;
+	grid-template-rows: masonry;
+	masonry-auto-flow: pack;
+	masonry-auto-flow: next;
+	masonry-auto-flow: pack definite-first;
+	masonry-auto-flow: next definite-first;
+}
+
+/**
  * CSS Basic User Interface Module Level 4
  */
 .ts-css-basic-user-interface-pointer-events {


### PR DESCRIPTION
* allow subgrid values for grid-template-columns and grid-template-rows
* allow masonry values for grid-template-columns and grid-template-rows
* add masonry-auto-flow property
* cover CSS Grid Levels 2 and 3 in tests
---
This PR is very lazy but should work