### PR TITLE
Backward compatibility for css-sanitizer 5.5.0

### DIFF
--- a/includes/MatcherFactoryExtender.php
+++ b/includes/MatcherFactoryExtender.php
@@ -357,12 +357,38 @@ class MatcherFactoryExtender extends MatcherFactory {
 	}
 
 	/**
+	 * Wraps the parent `calc` to allow using variables in the $typeMatcher
+	 *
+	 * For backward compatibility with css-sanitizer <=5.5.0.
+	 * Prefer mathFunction; it will fallback to calc.
+	 *
+	 * @param Matcher $typeMatcher
+	 * @param string $type
+	 * @return Matcher
+	 */
+	public function calc( Matcher $typeMatcher, $type ) {
+		if ( !$this->varEnabled ) {
+			return parent::calc( $typeMatcher, $type );
+		}
+
+		return parent::calc( new Alternative( [
+			$typeMatcher,
+			new FunctionMatcher( 'var', new CustomPropertyMatcher() ),
+		] ), $type );
+	}
+
+	/**
 	 * Wraps the parent `mathFunction` to allow using variables in the $typeMatcher
 	 *
 	 * @param Matcher $typeMatcher
 	 * @return Matcher
 	 */
 	public function mathFunction( Matcher $typeMatcher ) {
+		// b/c for css-sanitizer <=5.5.0.
+		if ( !method_exists( get_parent_class( $this ),  'mathFunction' ) ) {
+			return $this->calc( $typeMatcher, 'number' );
+		}
+
 		if ( !$this->varEnabled ) {
 			return parent::mathFunction( $typeMatcher );
 		}


### PR DESCRIPTION
Follow-up of #38.

Sorry I misunderstood "a breaking change" (: PR #38 is not a breaking change for CSS writers but a breaking change for wiki admins.

This should fix backward compatibility with older versions.

cc. @ihaveamac @octfx could you please review this? Thank you!